### PR TITLE
Rehook

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.25
+current_version = 0.1.26
 commit = False
 tag = False
 tag_name = {new_version}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 CHANGE LOG
 ==========
 
+0.1.26 - 2019.02.05
+-------------------
+* [ENHANCEMENT] Fix distutils issue, improve error handling, update versions.
+
 0.1.25 - 2019.01.31
 -------------------
 * [ENHANCEMENT] Add distutils to builds.

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ pylint = "==2.2.2"
 pytest = "==4.2.0"
 
 [packages]
-distlib = "==0.2.8"
 setuptools = "==40.6.3"
 click = "==7.0"
 PyInstaller = "==3.4"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,6 @@ pytest = "==4.2.0"
 setuptools = "==40.7.3"
 click = "==7.0"
 PyInstaller = "==3.4"
-pyppyn = "==0.3.9"
+pyppyn = "==0.3.10"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ pylint = "==2.2.2"
 pytest = "==4.2.0"
 
 [packages]
-setuptools = "==40.6.3"
+setuptools = "==40.7.3"
 click = "==7.0"
 PyInstaller = "==3.4"
 pyppyn = "==0.3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5396a429290e926654fe824a33080e06dc7ad4438e02cb51756321b94e916194"
+            "sha256": "b89602fa95df23c9b5acd181d2fdb78bf079c1b960bd0e3d7a88282a74394ade"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -33,7 +33,6 @@
             "hashes": [
                 "sha256:57977cd7d9ea27986ec62f425630e4ddb42efe651ff80bc58ed8dbc3c7c21f19"
             ],
-            "index": "pypi",
             "version": "==0.2.8"
         },
         "future": {
@@ -88,10 +87,10 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
-                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
             ],
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "attrs": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b89602fa95df23c9b5acd181d2fdb78bf079c1b960bd0e3d7a88282a74394ade"
+            "sha256": "555697b52883e033214f648a5cd99f34a5ce4df6bc23c83ff4028b6fc90a49bb"
         },
         "pipfile-spec": 6,
         "requires": {},

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "555697b52883e033214f648a5cd99f34a5ce4df6bc23c83ff4028b6fc90a49bb"
+            "sha256": "b9fa6cc9fbf990ab32abeb8394949af76694638124dede8d8c165c2be98c1a13"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -28,12 +28,6 @@
             ],
             "index": "pypi",
             "version": "==7.0"
-        },
-        "distlib": {
-            "hashes": [
-                "sha256:57977cd7d9ea27986ec62f425630e4ddb42efe651ff80bc58ed8dbc3c7c21f19"
-            ],
-            "version": "==0.2.8"
         },
         "future": {
             "hashes": [
@@ -63,11 +57,11 @@
         },
         "pyppyn": {
             "hashes": [
-                "sha256:39814ee4cd12debf8eb743ce4179e1c249d8167828871d0d24e2ab71d1482111",
-                "sha256:fb963848b0fbcd92a63cc17dccc40ac2166543a16296d6e8cd3d4224ecac3b62"
+                "sha256:66a31b3495c0dedac36b4cd10464d2d66ee749241e0ff143cd2f90fa472f17bf",
+                "sha256:e4155b33c23506d624a96c03c350875ced1dd620bd1c3bc72c60669de4dd7300"
             ],
             "index": "pypi",
-            "version": "==0.3.9"
+            "version": "==0.3.10"
         },
         "wheel": {
             "hashes": [

--- a/gravitybee/__init__.py
+++ b/gravitybee/__init__.py
@@ -426,6 +426,24 @@ class PackageGenerator():
         if not os.path.exists(self.args.directories["work"]):
             os.makedirs(self.args.directories["work"])
 
+        commands = [
+            'git',
+            'clone',
+            'https://github.com/pyinstaller/pyinstaller.git',
+            os.path.join(self.args.directories["work"], 'pyinstaller'),
+        ]
+
+        subproc_args = {}
+        subproc_args['check'] = True
+
+        subprocess.run(commands, **subproc_args)
+
+        shutil.copytree(os.path.join(
+            self.args.directories["work"],
+            'pyinstaller',
+            'PyInstaller',
+            'hooks'), os.path.join(self.args.directories["work"], 'hooks'))
+
         if not os.path.exists(FILE_DIR):
             os.makedirs(FILE_DIR)
 
@@ -475,6 +493,7 @@ class PackageGenerator():
         # 3 - write file
         self.files["hook"] = os.path.join(
             self.args.directories["work"],
+            'hooks',
             "hook-" + self.args.info["pkg_name"] + ".py"
         )
         hook_file = open(self.files["hook"], "w+")
@@ -818,7 +837,8 @@ class PackageGenerator():
             '--noconfirm',
             '--name', self.standalone_name,
             '--paths', self.args.directories["src"],
-            '--additional-hooks-dir', self.args.directories["work"],
+            '--additional-hooks-dir', os.path.join(
+                self.args.directories["work"], 'hooks'),
             '--specpath', self.args.directories["work"],
             '--workpath', os.path.join(self.args.directories["work"], 'build'),
             '--distpath', os.path.join(self.args.directories["work"], 'dist'),

--- a/gravitybee/__init__.py
+++ b/gravitybee/__init__.py
@@ -426,23 +426,9 @@ class PackageGenerator():
         if not os.path.exists(self.args.directories["work"]):
             os.makedirs(self.args.directories["work"])
 
-        commands = [
-            'git',
-            'clone',
-            'https://github.com/pyinstaller/pyinstaller.git',
-            os.path.join(self.args.directories["work"], 'pyinstaller'),
-        ]
-
-        subproc_args = {}
-        subproc_args['check'] = True
-
-        subprocess.run(commands, **subproc_args)
-
-        shutil.copytree(os.path.join(
-            self.args.directories["work"],
-            'pyinstaller',
-            'PyInstaller',
-            'hooks'), os.path.join(self.args.directories["work"], 'hooks'))
+        if not os.path.exists(
+                os.path.join(self.args.directories["work"], 'hooks')):
+            os.makedirs(os.path.join(self.args.directories["work"], 'hooks'))
 
         if not os.path.exists(FILE_DIR):
             os.makedirs(FILE_DIR)

--- a/gravitybee/__init__.py
+++ b/gravitybee/__init__.py
@@ -864,24 +864,22 @@ class PackageGenerator():
         logger.info(", ".join(commands))
 
         subproc_args = {}
-        subproc_args['check'] = True
+        subproc_args['check'] = False
 
         subproc_args['stdout'] = subprocess.PIPE
         subproc_args['stderr'] = subprocess.PIPE
 
-        result = None
-
-        try:
-            result = subprocess.run(commands, **subproc_args)
-        except subprocess.CalledProcessError:
-            logger.error("Non-zero exit code from pyinstaller")
-            return EXIT_NOT_OKAY
+        result = subprocess.run(commands, **subproc_args)
 
         if result.stdout:
             logger.debug(result.stdout.decode('utf-8'))
 
         if result.stderr and result.stderr != result.stdout:
             logger.error(result.stderr.decode('utf-8'))
+
+        if result.returncode != 0:
+            logger.error("PyInstaller exited with error code %s", result.returncode)
+            return EXIT_NOT_OKAY
 
         # get info about standalone binary
         for standalone in glob.glob(

--- a/gravitybee/__init__.py
+++ b/gravitybee/__init__.py
@@ -29,7 +29,7 @@ from gravitybee.distutils_utils import replace_venv_distutils,\
     unreplace_venv_distutils
 
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"
 EXIT_OKAY = 0
 EXIT_NOT_OKAY = 1
 FILE_DIR = ".gravitybee"

--- a/gravitybee/__init__.py
+++ b/gravitybee/__init__.py
@@ -13,18 +13,20 @@ Example:
         $ gravitybee --help
 """
 
-import os
-from string import Template
-import json
+import glob
 import hashlib
+import json
 import logging
 import logging.config
+import os
 import platform
 import shutil
 import subprocess
 import uuid
-import glob
+from string import Template
 import pyppyn
+from gravitybee.distutils_utils import replace_venv_distutils,\
+    unreplace_venv_distutils
 
 
 __version__ = "0.1.25"
@@ -804,6 +806,8 @@ class PackageGenerator():
         """Generate the standalone application."""
         self._create_hook()
 
+        replace_venv_distutils()
+
         try:
             shutil.copy2(self.args.info["script_path"], self._temp_script)
         except FileNotFoundError:
@@ -877,8 +881,11 @@ class PackageGenerator():
         if result.stderr and result.stderr != result.stdout:
             logger.error(result.stderr.decode('utf-8'))
 
+        unreplace_venv_distutils()
+
         if result.returncode != 0:
-            logger.error("PyInstaller exited with error code %s", result.returncode)
+            logger.error(
+                "PyInstaller exited with error code %s", result.returncode)
             return EXIT_NOT_OKAY
 
         # get info about standalone binary

--- a/gravitybee/__init__.py
+++ b/gravitybee/__init__.py
@@ -368,19 +368,19 @@ class PackageGenerator():
     # https://github.com/pyinstaller/pyinstaller/issues/1935
 
     EXTRA_REQD_PACKAGES = [
-        'packaging',
-        'configparser',
-        'setuptools'
+        # 'packaging',
+        # 'configparser',
+        # 'setuptools'
     ]
 
     EXTRA_REQD_MODULES = [
-        'packaging',
-        'configparser',
-        'packaging.version',
-        'packaging.specifiers',
-        'pkg_resources',
-        'html.parser',
-        'distutils'
+        # 'packaging',
+        # 'configparser',
+        # 'packaging.version',
+        # 'packaging.specifiers',
+        # 'pkg_resources',
+        # 'html.parser',
+        # 'distutils'
     ]
 
     @classmethod

--- a/gravitybee/__init__.py
+++ b/gravitybee/__init__.py
@@ -201,9 +201,7 @@ class Arguments():
         )
 
         # arguments that DO depend on pyppyn
-        self.pyppy = pyppyn.ConfigRep(
-            setup_path=self.directories["pkg"]
-        )
+        self.pyppy = pyppyn.ConfigRep(setup_path=self.directories["pkg"])
 
         self.info["console_script"] = self.pyppy.get_config_attr(
             'console_scripts'

--- a/gravitybee/distutils_utils.py
+++ b/gravitybee/distutils_utils.py
@@ -1,7 +1,8 @@
+# -*- coding: utf-8 -*-
 """Utilities for fixing issues with distutils."""
 
 import distutils
-from distutils.sysconfig import get_python_lib
+from distutils.sysconfig import get_python_lib   # pylint: disable=import-error
 import os
 import shutil
 

--- a/gravitybee/distutils_utils.py
+++ b/gravitybee/distutils_utils.py
@@ -1,5 +1,20 @@
 # -*- coding: utf-8 -*-
-"""Utilities for fixing issues with distutils."""
+"""Utilities for fixing issues with distutils.
+
+In a virtual env, distutils is not an actual package but a skeleton pointing
+to the non-virtual Python install distutils. The pyinstaller distutils hook is
+supposed to handle this issue and ensure that the real distutils is included
+with standalone packages. However, the hook has not been working and the
+maintainers seem uninterested in discussing:
+https://github.com/pyinstaller/pyinstaller/issues/4031
+
+This is a workaround.
+
+replace_venv_distutils() copies the real distutils directory into the virtual
+env and unreplace_venv_distutils() puts everything back. This can be used in
+gravitybee right before building the standalone. If the hook works, these
+utilities will have no effect. If the hook doesn't work, it will allow
+standalones to still have a valid copy of distutils."""
 
 import distutils
 from distutils.sysconfig import get_python_lib   # pylint: disable=import-error

--- a/gravitybee/distutils_utils.py
+++ b/gravitybee/distutils_utils.py
@@ -1,0 +1,35 @@
+"""Utilities for fixing issues with distutils."""
+
+import distutils
+from distutils.sysconfig import get_python_lib
+import os
+import shutil
+
+
+def _get_real_distutils_path():
+    distutils_dir = getattr(distutils, 'distutils_path', None)
+    if distutils_dir is None:
+        raise NotADirectoryError("Unable to find distutils")
+    return os.path.dirname(distutils_dir)
+
+
+def _get_venv_distutils_parent():
+    return os.path.abspath(os.path.join(get_python_lib(), os.pardir))
+
+
+def _get_venv_distutils_path():
+    return os.path.join(_get_venv_distutils_parent(), 'distutils')
+
+
+def replace_venv_distutils():
+    """Replace the fake distutils dir in virtual env with real distutils."""
+    shutil.move(
+        _get_venv_distutils_path(), _get_venv_distutils_path() + '-moved')
+    shutil.copytree(_get_real_distutils_path(), _get_venv_distutils_path())
+
+
+def unreplace_venv_distutils():
+    """Put fake distutils dir back after it has been replaced with real."""
+    shutil.rmtree(_get_venv_distutils_path())
+    shutil.move(
+        _get_venv_distutils_path() + '-moved', _get_venv_distutils_path())

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
   setuptools==40.7.3
   click==7.0
   PyInstaller==3.4
-  pyppyn==0.3.9
+  pyppyn==0.3.10
 packages = gravitybee
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,7 @@ classifiers =
 
 [options]
 install_requires = 
-  distlib==0.2.8
-  setuptools==40.6.3
+  setuptools==40.7.2
   click==7.0
   PyInstaller==3.4
   pyppyn==0.3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 
 [options]
 install_requires = 
-  setuptools==40.7.2
+  setuptools==40.7.3
   click==7.0
   PyInstaller==3.4
   pyppyn==0.3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = gravitybee
 description = Generate standalone python applications.
 long_description = file: README.rst, CHANGELOG.rst
-version = 0.1.25
+version = 0.1.26
 author = YakDriver
 author_email = projects@plus3it.com
 url = https://github.com/plus3it/gravitybee


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Fix issue with pyinstaller distutils hook not working properly
* Make error handling more graceful to clean-up and display pyinstaller output 
* Update versions
* Place custom-made hook in "hooks" directory
* Remove no-longer necessary kludges with including extra packages

Output from Pytest:

```console
158.54s$ pytest
============================= test session starts ==============================
platform linux -- Python 3.7.1, pytest-4.2.0, py-1.7.0, pluggy-0.8.0
rootdir: /home/travis/build/YakDriver/gravitybee, inifile: setup.cfg
collected 20 items                                                             
tests/test_gravitybee.py ....................                            [100%]
========================= 20 passed in 158.15 seconds ==========================
The command "pytest" exited with 0.

```